### PR TITLE
Add ability for the TSNE script to use the tfjs-node library

### DIFF
--- a/similarity/package.json
+++ b/similarity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vikus-viewer-tsne",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "tsne preprocessing script for vikus-viewer",
   "author": "Christopher Pietsch <cpietsch@gmail.com>",
   "private": true,

--- a/similarity/tsne.js
+++ b/similarity/tsne.js
@@ -8,7 +8,7 @@ var path = require("path");
 const glob = require('glob-promise');
 const localPath = i => path.relative(process.cwd(), i)
 const argv = require('minimist')(process.argv.slice(2));
-const tf = require('@tensorflow/tfjs');
+// const tf = require('@tensorflow/tfjs');
 // const tsne = require('@tensorflow/tfjs-tsne');
 const { createCanvas, loadImage } = require('canvas')
 const tsnejs = require('./lib/tsne.js');
@@ -20,6 +20,20 @@ console.log('starting with', process.argv);
 
 const inputPath = argv.i;
 const inputFormat = argv.f || 'jpg';
+const useTfjsnode = argv.t || false;
+
+var tf
+if(useTfjsnode) {
+  tf = require('@tensorflow/tfjs-node');
+}
+else {
+  tf = require('@tensorflow/tfjs');
+}
+
+const saveCsv = async (data, filename) => { 
+  const csv = d3.csvFormat(data) 
+  fs.writeFileSync(filename, csv);
+}
 
 const saveCsv = async (data, filename) => { 
   const csv = d3.csvFormat(data) 

--- a/similarity/tsne.js
+++ b/similarity/tsne.js
@@ -35,11 +35,6 @@ const saveCsv = async (data, filename) => {
   fs.writeFileSync(filename, csv);
 }
 
-const saveCsv = async (data, filename) => { 
-  const csv = d3.csvFormat(data) 
-  fs.writeFileSync(filename, csv);
-}
-
 async function run() {
   // todo load via tf
   // const MOBILENET_MODEL_PATH ='https://storage.googleapis.com/tfjs-models/tfjs/mobilenet_v1_0.25_224/model.json';


### PR DESCRIPTION
When running the TSNE script, the `@tensorflow/tfjs` library prints a message to console suggesting that the `@tensorflow/tfjs-node` library is a much faster alternative. This library is already in the `package.json`, but is not called in the code. I observed that it does not work on all systems (e.g. on Alpine Linux due to differences between musl and glibc that are not fixable with the compatibility layer), so perhaps this is why?

Testing a straight swap of libraries showed a speed improvement of over 30x - based on 43 input images and using `time node tsne.js -i /data/vikus/images/input/` for measurement, it went from 2m32s to 5s.

This PR adds the ability to switch to the `@tensorflow/tfjs-node` library by passing a flag to the script `-t`. I left the original `@tensorflow/tfjs` library as the default to ensure that this would not break existing deployments.